### PR TITLE
Allow compatibility with BasicObject and descendants.

### DIFF
--- a/lib/allocation_stats.rb
+++ b/lib/allocation_stats.rb
@@ -2,6 +2,7 @@
 # Licensed under the Apache License, Version 2.0, found in the LICENSE file.
 
 require "objspace"
+require_relative "allocation_stats/core_ext/basic_object"
 require_relative "allocation_stats/allocation"
 require_relative "allocation_stats/allocations_proxy"
 
@@ -62,8 +63,8 @@ class AllocationStats
     @existing_object_ids = {}
 
     ObjectSpace.each_object.to_a.each do |object|
-      @existing_object_ids[object.object_id / 1000] ||= []
-      @existing_object_ids[object.object_id / 1000] << object.object_id
+      @existing_object_ids[object.__id__ / 1000] ||= []
+      @existing_object_ids[object.__id__ / 1000] << object.__id__
     end
 
     ObjectSpace.trace_object_allocations {
@@ -84,8 +85,8 @@ class AllocationStats
     @existing_object_ids = {}
 
     ObjectSpace.each_object.to_a.each do |object|
-      @existing_object_ids[object.object_id / 1000] ||= []
-      @existing_object_ids[object.object_id / 1000] << object.object_id
+      @existing_object_ids[object.__id__ / 1000] ||= []
+      @existing_object_ids[object.__id__ / 1000] << object.__id__
     end
 
     ObjectSpace.trace_object_allocations_start
@@ -98,8 +99,8 @@ class AllocationStats
     ObjectSpace.each_object.to_a.each do |object|
       next if ObjectSpace.allocation_sourcefile(object).nil?
       next if ObjectSpace.allocation_sourcefile(object) == __FILE__
-      next if @existing_object_ids[object.object_id / 1000] &&
-              @existing_object_ids[object.object_id / 1000].include?(object.object_id)
+      next if @existing_object_ids[object.__id__ / 1000] &&
+              @existing_object_ids[object.__id__ / 1000].include?(object.__id__)
 
       @new_allocations << Allocation.new(object)
     end

--- a/lib/allocation_stats/allocations_proxy.rb
+++ b/lib/allocation_stats/allocations_proxy.rb
@@ -175,9 +175,9 @@ class AllocationStats
           lambda { |allocation| allocation.sourcefile(@alias_paths) }
         elsif Allocation::HELPERS.include?(faux) ||
               Allocation::ATTRIBUTES.include?(faux)
-          lambda { |allocation| allocation.send(faux) }
+          lambda { |allocation| allocation.__send__(faux) }
         else
-          lambda { |allocation| allocation.object.send(faux) }
+          lambda { |allocation| allocation.object.__send__(faux) }
         end
       end
     end

--- a/lib/allocation_stats/core_ext/basic_object.rb
+++ b/lib/allocation_stats/core_ext/basic_object.rb
@@ -1,0 +1,5 @@
+class BasicObject
+  def class
+    (class << self; self end).superclass
+  end
+end


### PR DESCRIPTION
If you try to use `AllocationStats.trace` and any descendant of `BasicObject` (but not `Object`) is created during the block, it will fail from calling `object_id` and `send`. `BasicObject` does not implement those two methods, but does use `__id__` and `__send__`.

That was a simple refactor. The slightly more complicated problem is that `BasicObject#class` does not exist. I found a way to implement `#class` by referencing the **superclass** of a `BasicObject`'s **eigenclass**.

Let me know if there's anything else you want me to add to the pull request.
- use `#__id__` instead of `#object_id`
- use `#__send__` instead of `#send`
- monkey patch `BasicObject` to give it #class using this hack found here:
  http://stackoverflow.com/a/10216927
