### PR TITLE
Fix wrong output of example in README

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -129,7 +129,7 @@ ObjectSpace.trace_object_allocations do
   puts ObjectSpace.allocation_sourceline(a)
 end
 $ ruby ./examples/trace_object_allocations.rb
-allocations.rb
+./examples/trace_object_allocations.rb
 4
 ```
 


### PR DESCRIPTION
I was irritated for a second when I saw a different filename in the output. So here's the fix that matches the actual output of the script.